### PR TITLE
feat: Add proxy-aware client IP handling for probe security

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,52 @@ curl -f http://localhost:8000/readyz
 curl -f http://localhost:8000/version
 ```
 
+Custom check messages are hidden by default. If you enable `EXPOSE_CHECK_MESSAGES=True`, do not include secrets or sensitive values in those messages.
+
+Security checks use `REMOTE_ADDR` by default. If probes are accessed through a trusted reverse proxy, configure `TRUSTED_PROXY_NETWORKS` and `CLIENT_IP_HEADER` to resolve the original client IP safely.
+
+### Common settings
+
+```python
+DEPLOY_PROBES = {
+    "SERVICE_NAME": "my-django-app",
+    "ENVIRONMENT": "prod",
+    "VERSION": "1.2.0",
+    "READY_CHECKS": ["database", "redis", "celery"],
+    "STARTUP_CHECKS": ["migrations"],
+    "READY_CUSTOM_CHECKS": [],
+    "STARTUP_CUSTOM_CHECKS": [],
+    "DATABASES": ["default"],
+    "REDIS": {
+        "default": {
+            "LOCATION": "redis://localhost:6379/0",
+            "TIMEOUT": 1.0,
+        },
+    },
+    "CELERY": {
+        "BROKER": True,
+        "WORKERS": False,
+        "RESULT_BACKEND": False,
+        "TIMEOUT": 1.0,
+    },
+    "DETAIL_LEVEL": "none",
+    "INCLUDE_CHECK_DURATIONS": False,
+    "REQUIRE_READY_CHECKS": False,
+    "REQUIRE_STARTUP_CHECKS": False,
+    "EXPOSE_CHECK_MESSAGES": False,
+    "INTERNAL_IP_ONLY": False,
+    "INTERNAL_IP_NETWORKS": [
+        "127.0.0.1/32",
+        "::1/128",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+    ],
+    "TRUSTED_PROXY_NETWORKS": [],
+    "CLIENT_IP_HEADER": None,
+}
+```
+
 ## Development
 
 ```bash

--- a/django_deploy_probes/conf.py
+++ b/django_deploy_probes/conf.py
@@ -42,6 +42,8 @@ DEFAULT_DEPLOY_PROBES = {
         "172.16.0.0/12",
         "192.168.0.0/16",
     ],
+    "TRUSTED_PROXY_NETWORKS": [],
+    "CLIENT_IP_HEADER": None,
     "HEADER_TOKEN_VALIDATION": False,
     "ENABLE_OPENAPI": False,
     "OPENAPI_TAG": "Deployment Probes",

--- a/django_deploy_probes/django_checks.py
+++ b/django_deploy_probes/django_checks.py
@@ -32,6 +32,8 @@ def check_deploy_probes_settings(app_configs, **kwargs):
     messages.extend(_check_custom_check_list("STARTUP_CUSTOM_CHECKS", merged))
     messages.extend(_check_detail_level(merged))
     messages.extend(_check_internal_networks(merged))
+    messages.extend(_check_trusted_proxy_networks(merged))
+    messages.extend(_check_client_ip_header(merged))
     messages.extend(_check_header_token(merged))
     messages.extend(_check_redis_config(merged))
     messages.extend(_check_require_checks(merged))
@@ -95,18 +97,66 @@ def _check_detail_level(probes_settings):
 
 
 def _check_internal_networks(probes_settings):
+    return _check_network_list(
+        key="INTERNAL_IP_NETWORKS",
+        value=probes_settings.get("INTERNAL_IP_NETWORKS", []),
+        error_id="django_deploy_probes.E005",
+    )
+
+
+def _check_trusted_proxy_networks(probes_settings):
+    return _check_network_list(
+        key="TRUSTED_PROXY_NETWORKS",
+        value=probes_settings.get("TRUSTED_PROXY_NETWORKS", []),
+        error_id="django_deploy_probes.E011",
+    )
+
+
+def _check_network_list(key, value, error_id):
+    if not isinstance(value, (list, tuple)):
+        return [
+            Error(
+                f"DEPLOY_PROBES['{key}'] must be a list or tuple.",
+                id=error_id,
+            )
+        ]
+
     messages = []
-    for network in probes_settings.get("INTERNAL_IP_NETWORKS", []):
+    for network in value:
         try:
             ip_network(network)
         except ValueError:
             messages.append(
                 Error(
-                    f"Invalid internal IP network: {network}.",
-                    id="django_deploy_probes.E005",
+                    f"Invalid {key} entry: {network}.",
+                    id=error_id,
                 )
             )
     return messages
+
+
+def _check_client_ip_header(probes_settings):
+    client_ip_header = probes_settings.get("CLIENT_IP_HEADER")
+    if client_ip_header in (None, False, ""):
+        return []
+
+    if not isinstance(client_ip_header, str):
+        return [
+            Error(
+                "DEPLOY_PROBES['CLIENT_IP_HEADER'] must be a string or None.",
+                id="django_deploy_probes.E012",
+            )
+        ]
+
+    if not probes_settings.get("TRUSTED_PROXY_NETWORKS"):
+        return [
+            Warning(
+                "CLIENT_IP_HEADER is configured without TRUSTED_PROXY_NETWORKS and will be ignored.",
+                id="django_deploy_probes.W004",
+            )
+        ]
+
+    return []
 
 
 def _check_header_token(probes_settings):

--- a/django_deploy_probes/security.py
+++ b/django_deploy_probes/security.py
@@ -14,10 +14,31 @@ def is_internal_ip(remote_addr, networks):
     return any(request_ip in network for network in parsed_networks)
 
 
+def get_request_ip(request, probes_settings):
+    remote_addr = request.META.get("REMOTE_ADDR", "")
+    client_ip_header = probes_settings.get("CLIENT_IP_HEADER")
+    trusted_proxy_networks = probes_settings.get("TRUSTED_PROXY_NETWORKS", [])
+
+    if not client_ip_header or not trusted_proxy_networks:
+        return remote_addr
+
+    if not is_internal_ip(remote_addr, trusted_proxy_networks):
+        return remote_addr
+
+    header_value = request.headers.get(client_ip_header, "")
+    forwarded_ip = _extract_forwarded_client_ip(
+        client_ip_header,
+        header_value,
+        trusted_proxy_networks,
+        remote_addr,
+    )
+    return forwarded_ip or remote_addr
+
+
 def security_forbidden_response(request, probes_settings, protect_healthz=False):
     if not protect_healthz or _protect_healthz_enabled(probes_settings):
         if probes_settings["INTERNAL_IP_ONLY"] and not is_internal_ip(
-            request.META.get("REMOTE_ADDR", ""),
+            get_request_ip(request, probes_settings),
             probes_settings["INTERNAL_IP_NETWORKS"],
         ):
             return HttpResponseForbidden()
@@ -41,3 +62,45 @@ def _protect_healthz_enabled(probes_settings):
     if isinstance(header_token_validation, dict):
         return header_token_validation.get("PROTECT_HEALTHZ", False)
     return False
+
+
+def _extract_forwarded_client_ip(
+    client_ip_header,
+    header_value,
+    trusted_proxy_networks,
+    remote_addr,
+):
+    if not header_value:
+        return None
+
+    if client_ip_header.lower() == "x-forwarded-for":
+        return _extract_x_forwarded_for_client_ip(
+            header_value,
+            trusted_proxy_networks,
+            remote_addr,
+        )
+
+    return _normalize_ip_value(header_value)
+
+
+def _extract_x_forwarded_for_client_ip(header_value, trusted_proxy_networks, remote_addr):
+    forwarded_ips = [ip.strip() for ip in header_value.split(",") if ip.strip()]
+    if not forwarded_ips:
+        return None
+
+    normalized_ips = [_normalize_ip_value(ip) for ip in forwarded_ips]
+    if any(ip is None for ip in normalized_ips):
+        return None
+
+    for candidate_ip in reversed([*normalized_ips, remote_addr]):
+        if not is_internal_ip(candidate_ip, trusted_proxy_networks):
+            return candidate_ip
+
+    return normalized_ips[0]
+
+
+def _normalize_ip_value(value):
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError:
+        return None

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,13 @@ DEPLOY_PROBES = {
     "EXPOSE_VERSION": True,
     "EXPOSE_BUILD_INFO": False,
     "INTERNAL_IP_ONLY": False,
+    "INTERNAL_IP_NETWORKS": [
+        "127.0.0.1/32",
+        "::1/128",
+        "10.0.0.0/8",
+    ],
+    "TRUSTED_PROXY_NETWORKS": [],
+    "CLIENT_IP_HEADER": None,
     "HEADER_TOKEN_VALIDATION": False,
     "ENABLE_OPENAPI": False,
 }
@@ -136,3 +143,8 @@ python manage.py check
 startup behavior stay independent.
 
 Validation catches common mistakes such as unknown check names, invalid custom check lists, invalid CIDR ranges, missing Redis locations, invalid `DETAIL_LEVEL`, and missing probe tokens.
+
+When probes are accessed through a trusted reverse proxy, set `TRUSTED_PROXY_NETWORKS` and
+`CLIENT_IP_HEADER` so `INTERNAL_IP_ONLY` can evaluate the original client IP instead of the
+proxy hop. `X-Forwarded-For` is resolved by walking the proxy chain from right to left and
+selecting the last untrusted address as the client IP.

--- a/docs/ja.md
+++ b/docs/ja.md
@@ -46,7 +46,7 @@ urlpatterns = [
 
 `/readyz` のカスタム check メッセージはデフォルトで非表示です。`EXPOSE_CHECK_MESSAGES=True` を使う場合は、secret や機密情報をメッセージに含めないでください。
 
-Security check はデフォルトで `REMOTE_ADDR` を使用し、`X-Forwarded-For` は信頼しません。Proxy 経由で probe にアクセスする場合は、reverse proxy を別途設定してください。
+Security check はデフォルトで `REMOTE_ADDR` を使用します。Trusted reverse proxy の背後で probe にアクセスする場合は、`TRUSTED_PROXY_NETWORKS` と `CLIENT_IP_HEADER` を設定して元の client IP を安全に判定してください。
 
 ## ビルドと公開
 

--- a/docs/ko.md
+++ b/docs/ko.md
@@ -46,7 +46,7 @@ urlpatterns = [
 
 `/readyz`의 사용자 정의 check 메시지는 기본적으로 숨겨집니다. `EXPOSE_CHECK_MESSAGES=True`를 사용하는 경우 메시지에 secret이나 민감한 값을 포함하지 마세요.
 
-Security check는 기본적으로 `REMOTE_ADDR`을 사용하며 `X-Forwarded-For`를 신뢰하지 않습니다. Proxy를 통해 probe에 접근하는 경우 reverse proxy 설정은 별도로 구성하세요.
+Security check는 기본적으로 `REMOTE_ADDR`을 사용합니다. Trusted reverse proxy 뒤에서 probe에 접근하는 경우 `TRUSTED_PROXY_NETWORKS`와 `CLIENT_IP_HEADER`를 설정해 원래 client IP를 안전하게 판별하세요.
 
 ## 빌드 및 배포
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -139,10 +139,43 @@ If every endpoint returns `403`, check whether healthz protection is enabled:
 "PROTECT_HEALTHZ": False
 ```
 
-If proxy traffic is blocked, check the direct client IP seen by Django. This package uses `REMOTE_ADDR` for internal IP checks and does not trust `X-Forwarded-For`.
+If proxy traffic is blocked, check whether Django is seeing the proxy hop in `REMOTE_ADDR`. When
+probes are behind a trusted reverse proxy, configure `TRUSTED_PROXY_NETWORKS` and
+`CLIENT_IP_HEADER` so internal IP checks can evaluate the original client IP safely.
 
 If your probe traffic comes from a load balancer or private service network, add that CIDR to
 `INTERNAL_IP_NETWORKS`.
+
+## Trusted Reverse Proxy
+
+When probes are served behind ALB, Nginx, or an ingress controller, `REMOTE_ADDR` may be the
+proxy hop instead of the original client. In that case, configure a narrow trusted proxy CIDR
+list and the header that carries the client IP.
+
+```python
+DEPLOY_PROBES = {
+    "INTERNAL_IP_ONLY": True,
+    "INTERNAL_IP_NETWORKS": [
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+    ],
+    "TRUSTED_PROXY_NETWORKS": [
+        "192.0.2.10/32",
+        "192.0.2.11/32",
+    ],
+    "CLIENT_IP_HEADER": "X-Forwarded-For",
+}
+```
+
+Rules:
+
+- If `REMOTE_ADDR` is not in `TRUSTED_PROXY_NETWORKS`, forwarded headers are ignored.
+- If `CLIENT_IP_HEADER` is `X-Forwarded-For`, the package walks the proxy chain from right to
+  left and treats the last untrusted hop as the client IP.
+- Keep `TRUSTED_PROXY_NETWORKS` as narrow as possible. Do not trust an entire private range
+  unless every host in that range is an authorized proxy.
+- If your proxy uses a single-value header such as `X-Real-IP`, set `CLIENT_IP_HEADER` to that
+  header name instead.
 
 ## Next Step
 

--- a/docs/zh-CN.md
+++ b/docs/zh-CN.md
@@ -46,7 +46,7 @@ urlpatterns = [
 
 `/readyz` 的自定义 check 消息默认隐藏。使用 `EXPOSE_CHECK_MESSAGES=True` 时，请不要在消息中包含 secrets 或敏感值。
 
-Security checks 默认使用 `REMOTE_ADDR`，并且不信任 `X-Forwarded-For`。如果通过 proxy 访问 probes，请单独配置 reverse proxy。
+Security checks 默认使用 `REMOTE_ADDR`。如果 probes 位于 trusted reverse proxy 后面，请配置 `TRUSTED_PROXY_NETWORKS` 和 `CLIENT_IP_HEADER`，以安全地识别原始 client IP。
 
 ## 构建与发布
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -30,3 +30,5 @@ class DeployProbesSettingsTestCase(SimpleTestCase):
         self.assertEqual(probes_settings["DETAIL_LEVEL"], "none")
         self.assertIs(probes_settings["EXPOSE_CHECK_MESSAGES"], False)
         self.assertIn("127.0.0.1/32", probes_settings["INTERNAL_IP_NETWORKS"])
+        self.assertEqual(probes_settings["TRUSTED_PROXY_NETWORKS"], [])
+        self.assertIsNone(probes_settings["CLIENT_IP_HEADER"])

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -21,6 +21,24 @@ class DjangoChecksTestCase(SimpleTestCase):
 
         self.assertIn("django_deploy_probes.E005", {message.id for message in messages})
 
+    @override_settings(DEPLOY_PROBES={"TRUSTED_PROXY_NETWORKS": ["not-a-cidr"]})
+    def test_invalid_trusted_proxy_network_is_reported(self):
+        messages = run_checks()
+
+        self.assertIn("django_deploy_probes.E011", {message.id for message in messages})
+
+    @override_settings(DEPLOY_PROBES={"CLIENT_IP_HEADER": ["X-Forwarded-For"]})
+    def test_invalid_client_ip_header_type_is_reported(self):
+        messages = run_checks()
+
+        self.assertIn("django_deploy_probes.E012", {message.id for message in messages})
+
+    @override_settings(DEPLOY_PROBES={"CLIENT_IP_HEADER": "X-Forwarded-For"})
+    def test_client_ip_header_without_trusted_proxies_is_reported(self):
+        messages = run_checks()
+
+        self.assertIn("django_deploy_probes.W004", {message.id for message in messages})
+
     @override_settings(
         DEPLOY_PROBES={
             "HEADER_TOKEN_VALIDATION": {

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -37,6 +37,91 @@ class SecurityTestCase(SimpleTestCase):
 
     @override_settings(
         DEPLOY_PROBES={
+            "INTERNAL_IP_ONLY": True,
+            "INTERNAL_IP_NETWORKS": ["10.0.0.0/8"],
+            "TRUSTED_PROXY_NETWORKS": ["192.0.2.0/24"],
+            "CLIENT_IP_HEADER": "X-Forwarded-For",
+        }
+    )
+    def test_internal_client_is_allowed_through_trusted_proxy(self):
+        response = self.client.get(
+            reverse("django_deploy_probes:version"),
+            REMOTE_ADDR="192.0.2.10",
+            HTTP_X_FORWARDED_FOR="10.1.2.3",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(
+        DEPLOY_PROBES={
+            "INTERNAL_IP_ONLY": True,
+            "INTERNAL_IP_NETWORKS": ["10.0.0.0/8"],
+            "TRUSTED_PROXY_NETWORKS": ["192.0.2.0/24"],
+            "CLIENT_IP_HEADER": "X-Forwarded-For",
+        }
+    )
+    def test_external_client_is_blocked_through_trusted_proxy(self):
+        response = self.client.get(
+            reverse("django_deploy_probes:version"),
+            REMOTE_ADDR="192.0.2.10",
+            HTTP_X_FORWARDED_FOR="198.51.100.7",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(
+        DEPLOY_PROBES={
+            "INTERNAL_IP_ONLY": True,
+            "INTERNAL_IP_NETWORKS": ["10.0.0.0/8"],
+            "TRUSTED_PROXY_NETWORKS": ["192.0.2.0/24"],
+            "CLIENT_IP_HEADER": "X-Forwarded-For",
+        }
+    )
+    def test_spoofed_forwarded_header_is_ignored_for_untrusted_proxy(self):
+        response = self.client.get(
+            reverse("django_deploy_probes:version"),
+            REMOTE_ADDR="198.51.100.9",
+            HTTP_X_FORWARDED_FOR="10.1.2.3",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(
+        DEPLOY_PROBES={
+            "INTERNAL_IP_ONLY": True,
+            "INTERNAL_IP_NETWORKS": ["10.0.0.0/8"],
+            "TRUSTED_PROXY_NETWORKS": ["192.0.2.0/24", "10.0.0.0/8"],
+            "CLIENT_IP_HEADER": "X-Forwarded-For",
+        }
+    )
+    def test_x_forwarded_for_uses_last_untrusted_hop_as_client_ip(self):
+        response = self.client.get(
+            reverse("django_deploy_probes:version"),
+            REMOTE_ADDR="192.0.2.10",
+            HTTP_X_FORWARDED_FOR="198.51.100.7, 10.9.9.9",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(
+        DEPLOY_PROBES={
+            "INTERNAL_IP_ONLY": True,
+            "INTERNAL_IP_NETWORKS": ["10.0.0.0/8"],
+            "TRUSTED_PROXY_NETWORKS": ["192.0.2.0/24"],
+            "CLIENT_IP_HEADER": "X-Real-IP",
+        }
+    )
+    def test_custom_client_ip_header_is_supported_for_trusted_proxy(self):
+        response = self.client.get(
+            reverse("django_deploy_probes:version"),
+            REMOTE_ADDR="192.0.2.10",
+            HTTP_X_REAL_IP="10.1.2.3",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(
+        DEPLOY_PROBES={
             "HEADER_TOKEN_VALIDATION": {
                 "HEADER_NAME": "X-Probe-Token",
                 "TOKEN": "secret-token",


### PR DESCRIPTION
## Summary

Add proxy-aware client IP resolution for probe security checks.

`INTERNAL_IP_ONLY` can now evaluate the original client IP when probes are served behind a trusted reverse proxy such as ALB, Nginx, or an ingress controller.

## Changes

- add `TRUSTED_PROXY_NETWORKS` and `CLIENT_IP_HEADER` settings
- use forwarded client IP only when the request comes from a trusted proxy
- support `X-Forwarded-For` chain parsing and single-value headers like `X-Real-IP`
- add Django system checks for trusted proxy CIDR and header validation
- update README and docs site content for reverse proxy deployments

## Why

Previously, security checks relied on `REMOTE_ADDR` only.
That works for direct access, but it breaks in common production topologies where Django sees the proxy hop instead of the original client IP.

This change keeps the default behavior safe while allowing explicit proxy-aware configuration for real deployment environments.

## Validation

- added security tests for trusted proxy, untrusted proxy, spoofed headers, and custom client IP headers
- added Django system check coverage for new settings
- ran `uv run pytest -q`

## Notes

- default behavior is unchanged when the new settings are not configured
- forwarded headers are ignored unless `REMOTE_ADDR` belongs to `TRUSTED_PROXY_NETWORKS`